### PR TITLE
TS-001: Add type declarations for untyped dependencies

### DIFF
--- a/v3/@claude-flow/codex/src/types/fs-extra.d.ts
+++ b/v3/@claude-flow/codex/src/types/fs-extra.d.ts
@@ -1,0 +1,10 @@
+declare module 'fs-extra' {
+  export function ensureDir(path: string): Promise<void>;
+  export function pathExists(path: string): Promise<boolean>;
+  export function readFile(path: string, encoding?: string): Promise<string>;
+  export function writeFile(path: string, data: string, encoding?: string): Promise<void>;
+  export function readdir(path: string, opts?: any): Promise<any[]>;
+  export function stat(path: string): Promise<any>;
+  export function remove(path: string): Promise<void>;
+  export function copy(src: string, dest: string, opts?: any): Promise<void>;
+}

--- a/v3/@claude-flow/embeddings/src/types/agentic-flow-embeddings.d.ts
+++ b/v3/@claude-flow/embeddings/src/types/agentic-flow-embeddings.d.ts
@@ -1,0 +1,8 @@
+declare module 'agentic-flow/embeddings' {
+  export interface ModelInfo { id: string; dimension: number; size: string; quantized: boolean; downloaded: boolean; }
+  export function getOptimizedEmbedder(opts: any): any;
+  export function getNeuralSubstrate(opts?: any): any;
+  export function listAvailableModels(): ModelInfo[];
+  export function downloadModel(modelId: string): Promise<void>;
+  export class OptimizedEmbedder { embed(text: string): Promise<Float32Array>; embedBatch(texts: string[]): Promise<Float32Array[]>; init(): Promise<void>; }
+}

--- a/v3/@claude-flow/mcp/src/types/cors.d.ts
+++ b/v3/@claude-flow/mcp/src/types/cors.d.ts
@@ -1,0 +1,5 @@
+declare module 'cors' {
+  interface CorsOptions { origin?: any; methods?: string | string[]; allowedHeaders?: string | string[]; credentials?: boolean; }
+  function cors(options?: CorsOptions): any;
+  export = cors;
+}

--- a/v3/@claude-flow/mcp/src/types/express.d.ts
+++ b/v3/@claude-flow/mcp/src/types/express.d.ts
@@ -1,0 +1,10 @@
+declare module 'express' {
+  export interface Request { body: any; params: any; query: any; headers: any; method: string; url: string; path: string; ip: string; }
+  export interface Response { status(code: number): Response; json(body: any): Response; send(body?: any): Response; set(field: string, value: string): Response; end(): void; locals: any; }
+  export interface NextFunction { (err?: any): void; }
+  export interface Express { use(...args: any[]): any; get(...args: any[]): any; post(...args: any[]): any; put(...args: any[]): any; delete(...args: any[]): any; listen(...args: any[]): any; }
+  export interface Router { use(...args: any[]): any; get(...args: any[]): any; post(...args: any[]): any; put(...args: any[]): any; delete(...args: any[]): any; }
+  function express(): Express;
+  namespace express { function Router(): Router; function json(opts?: any): any; function urlencoded(opts?: any): any; function static(root: string, opts?: any): any; }
+  export = express;
+}

--- a/v3/@claude-flow/performance/src/types/ruvector-attention.d.ts
+++ b/v3/@claude-flow/performance/src/types/ruvector-attention.d.ts
@@ -1,0 +1,17 @@
+declare module '@ruvector/attention' {
+  export interface AttentionConfig { dim: number; numHeads?: number; dropout?: number; blockSize?: number; }
+  export function scaledDotProductAttention(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array;
+  export function multiHeadAttention(q: Float32Array, k: Float32Array[], v: Float32Array[], c: AttentionConfig): Float32Array;
+  export function flashAttention(q: Float32Array, k: Float32Array[], v: Float32Array[], bs?: number): Float32Array;
+  export function hyperbolicAttention(q: Float32Array, k: Float32Array[], v: Float32Array[], c?: number): Float32Array;
+  export class FlashAttention { constructor(dim: number, blockSize?: number); compute(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; computeRaw(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; }
+  export class DotProductAttention { constructor(dim: number); compute(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; computeRaw(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; }
+  export class MultiHeadAttention { constructor(dim: number, heads?: number); compute(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; computeRaw(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; }
+  export class LinearAttention { constructor(dim: number); compute(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; computeRaw(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; }
+  export class HyperbolicAttention { constructor(dim: number, curvature?: number); compute(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; }
+  export class MoEAttention { constructor(dim: number, numExperts?: number); compute(q: Float32Array, k: Float32Array[], v: Float32Array[]): Float32Array; }
+  export class InfoNceLoss { constructor(config?: any); compute(a: Float32Array[], p: Float32Array[], n?: Float32Array[]): number; }
+  export class AdamWOptimizer { constructor(config?: any); step(p: Float32Array, g: Float32Array): Float32Array; }
+  export function benchmarkAttention(config: any): any;
+  export const version: string;
+}

--- a/v3/@claude-flow/shared/src/core/config/validator.ts
+++ b/v3/@claude-flow/shared/src/core/config/validator.ts
@@ -43,7 +43,7 @@ export interface ValidationError {
  * Convert Zod error to validation errors
  */
 function zodErrorToValidationErrors(error: ZodError): ValidationError[] {
-  return error.errors.map((e) => ({
+  return error.issues.map((e) => ({
     path: e.path.join('.'),
     message: e.message,
     code: e.code,

--- a/v3/@claude-flow/shared/src/types/express.d.ts
+++ b/v3/@claude-flow/shared/src/types/express.d.ts
@@ -1,0 +1,10 @@
+declare module 'express' {
+  export interface Request { body: any; params: any; query: any; headers: any; method: string; url: string; path: string; ip: string; }
+  export interface Response { status(code: number): Response; json(body: any): Response; send(body?: any): Response; set(field: string, value: string): Response; end(): void; locals: any; }
+  export interface NextFunction { (err?: any): void; }
+  export interface Express { use(...args: any[]): any; get(...args: any[]): any; post(...args: any[]): any; put(...args: any[]): any; delete(...args: any[]): any; listen(...args: any[]): any; }
+  export interface Router { use(...args: any[]): any; get(...args: any[]): any; post(...args: any[]): any; put(...args: any[]): any; delete(...args: any[]): any; }
+  function express(): Express;
+  namespace express { function Router(): Router; function json(opts?: any): any; function urlencoded(opts?: any): any; function static(root: string, opts?: any): any; }
+  export = express;
+}

--- a/v3/@claude-flow/testing/src/types/vitest.d.ts
+++ b/v3/@claude-flow/testing/src/types/vitest.d.ts
@@ -1,0 +1,12 @@
+declare module 'vitest' {
+  export function describe(name: string, fn: () => void): void;
+  export function it(name: string, fn: () => void | Promise<void>): void;
+  export function test(name: string, fn: () => void | Promise<void>): void;
+  export function expect(value: any): any;
+  export function beforeEach(fn: () => void | Promise<void>): void;
+  export function afterEach(fn: () => void | Promise<void>): void;
+  export function beforeAll(fn: () => void | Promise<void>): void;
+  export function afterAll(fn: () => void | Promise<void>): void;
+  export const vi: { fn: (...args: any[]) => any; spyOn: (...args: any[]) => any; mock: (...args: any[]) => any; mocked: <T>(item: T) => any; resetAllMocks: () => void; clearAllMocks: () => void; restoreAllMocks: () => void; };
+  export type Mock<T = any> = T & { mockReturnValue: (val: any) => Mock<T>; mockResolvedValue: (val: any) => Mock<T>; mockImplementation: (fn: any) => Mock<T>; mockRejectedValue: (val: any) => Mock<T>; };
+}


### PR DESCRIPTION
Fixes #11

Adds local `.d.ts` type declarations for 6 packages that fail full type-check due to missing types for optional/untyped dependencies. Also fixes ZodError API usage in shared (.`errors` -> `.issues`).

See ADR-0028 in ruflo-patch for full context.