### PR TITLE
MC-001: Remove autoStart: false from MCP config

### DIFF
--- a/v3/@claude-flow/cli/src/init/mcp-generator.ts
+++ b/v3/@claude-flow/cli/src/init/mcp-generator.ts
@@ -64,7 +64,7 @@ export function generateMCPConfig(options: InitOptions): object {
         CLAUDE_FLOW_MAX_AGENTS: String(options.runtime.maxAgents),
         CLAUDE_FLOW_MEMORY_BACKEND: options.runtime.memoryBackend,
       },
-      { autoStart: config.autoStart }
+      {}
     );
   }
 

--- a/v3/@claude-flow/cli/src/init/types.ts
+++ b/v3/@claude-flow/cli/src/init/types.ts
@@ -381,7 +381,7 @@ export const DEFAULT_INIT_OPTIONS: InitOptions = {
     claudeFlow: true,
     ruvSwarm: false,
     flowNexus: false,
-    autoStart: false,
+    autoStart: true,
     port: 3000,
   },
   runtime: {
@@ -510,7 +510,7 @@ export const FULL_INIT_OPTIONS: InitOptions = {
     claudeFlow: true,
     ruvSwarm: true,
     flowNexus: true,
-    autoStart: false,
+    autoStart: true,
     port: 3000,
   },
   embeddings: {


### PR DESCRIPTION
Fixes #1

MCP servers now auto-start by default. Removes autoStart: false from generated .mcp.json.