### PR TITLE
FB-004: Adaptive search threshold for hash vs ONNX embeddings

### DIFF
--- a/v3/@claude-flow/cli/src/memory/memory-bridge.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-bridge.ts
@@ -20,6 +20,28 @@
 import * as path from 'path';
 import * as crypto from 'crypto';
 
+// FB-004: Adaptive search threshold based on embedding model.
+// Hash fallback produces similarity ~0.05-0.28 (not semantic).
+// ONNX produces meaningful similarity 0.3-0.95.
+const HASH_THRESHOLD = 0.05;
+const ONNX_THRESHOLD = 0.3;
+let _detectedModel: string | null = null;
+
+async function _getAdaptiveThreshold(explicit?: number): Promise<number> {
+  if (explicit !== undefined && explicit !== null) return explicit;
+  if (!_detectedModel) {
+    try {
+      // Probe the embedding model once and cache
+      const { generateEmbedding } = await import('./memory-initializer.js');
+      const { model } = await generateEmbedding('probe');
+      _detectedModel = model;
+    } catch {
+      _detectedModel = 'hash-fallback';
+    }
+  }
+  return _detectedModel === 'hash-fallback' ? HASH_THRESHOLD : ONNX_THRESHOLD;
+}
+
 // ===== Lazy singleton =====
 
 let registryPromise: Promise<any> | null = null;
@@ -444,7 +466,8 @@ export async function bridgeSearchEntries(options: {
   if (!ctx) return null;
 
   try {
-    const { query: queryStr, namespace = 'default', limit = 10, threshold = 0.3 } = options;
+    const { query: queryStr, namespace = 'default', limit = 10, threshold: explicitThreshold } = options;
+    const threshold = await _getAdaptiveThreshold(explicitThreshold);
     const startTime = Date.now();
 
     // Generate query embedding
@@ -941,7 +964,7 @@ export async function bridgeSearchHNSW(
 
   try {
     const k = options?.k ?? 10;
-    const threshold = options?.threshold ?? 0.3;
+    const threshold = await _getAdaptiveThreshold(options?.threshold);
     const nsFilter = options?.namespace && options.namespace !== 'all'
       ? `AND namespace = ?`
       : '';
@@ -1197,7 +1220,7 @@ export async function bridgeSearchPatterns(options: {
       query: options.query,
       namespace: 'pattern',
       limit: options.topK || 5,
-      threshold: options.minConfidence || 0.3,
+      threshold: options.minConfidence || await _getAdaptiveThreshold(),
       dbPath: options.dbPath,
     });
 
@@ -1384,7 +1407,7 @@ export async function bridgeSessionStart(options: {
       query: options.context || 'session patterns',
       namespace: 'session',
       limit: 10,
-      threshold: 0.2,
+      threshold: await _getAdaptiveThreshold(),
       dbPath: options.dbPath,
     });
 

--- a/v3/@claude-flow/cli/src/memory/memory-initializer.ts
+++ b/v3/@claude-flow/cli/src/memory/memory-initializer.ts
@@ -1766,6 +1766,28 @@ function generateHashEmbedding(text: string, dimensions: number): number[] {
 }
 
 /**
+ * Get the appropriate similarity threshold for the current embedding model.
+ * Hash fallback embeddings produce similarity ~0.05-0.28 (not semantic).
+ * ONNX embeddings produce meaningful similarity 0.3-0.95.
+ *
+ * FB-004: Adaptive thresholds prevent silent empty results with hash embeddings.
+ */
+export async function getAdaptiveThreshold(explicitThreshold?: number): Promise<number> {
+  if (explicitThreshold !== undefined && explicitThreshold !== null) {
+    return explicitThreshold;
+  }
+  try {
+    const { model } = await generateEmbedding('threshold probe');
+    if (model === 'hash-fallback') {
+      return 0.05; // Hash: low threshold, ranking is noise
+    }
+    return 0.3; // ONNX: meaningful similarity scores
+  } catch {
+    return 0.05; // If embedding fails, use permissive threshold
+  }
+}
+
+/**
  * Verify memory initialization works correctly
  * Tests: write, read, search, patterns
  */
@@ -2129,9 +2151,11 @@ export async function searchEntries(options: {
     query,
     namespace = 'default',
     limit = 10,
-    threshold = 0.3,
+    threshold: explicitThreshold,
     dbPath: customPath
   } = options;
+  // FB-004: adaptive threshold based on embedding model
+  const threshold = await getAdaptiveThreshold(explicitThreshold);
 
   const swarmDir = path.join(process.cwd(), '.swarm');
   const dbPath = customPath || path.join(swarmDir, 'memory.db');


### PR DESCRIPTION
Fixes #3

Detects embedding model at runtime and applies 0.05 (hash) or 0.3 (ONNX) threshold instead of hardcoded 0.3 that filtered out 90% of results with hash embeddings.